### PR TITLE
Generalize transformer logic

### DIFF
--- a/assign/transformer.py
+++ b/assign/transformer.py
@@ -9,13 +9,10 @@ __all__ = [
 
 def gen_assign_checker_ast(node):
     targets = [t.id for t in node.targets]
-    obj_name = node.value.id
-
     return ast.If(
         test=ast.Call(
             func=ast.Name(id='hasattr', ctx=ast.Load()),
-            args=[
-                ast.Name(id=obj_name, ctx=ast.Load()),
+            args=[node.value,
                 ast.Str(s='__assign__'),
             ],
             keywords=[],
@@ -27,7 +24,7 @@ def gen_assign_checker_ast(node):
                 targets=[ast.Name(id=target, ctx=ast.Store())],
                 value=ast.Call(
                     func=ast.Attribute(
-                        value=ast.Name(id=obj_name, ctx=ast.Load()),
+                        value = node.value,
                         attr='__assign__',
                         ctx=ast.Load()
                     ),
@@ -36,8 +33,7 @@ def gen_assign_checker_ast(node):
                     starargs=None,
                     kwargs=None
                 )
-            )
-            for target in targets],
+            ) for target in targets],
         orelse=[]
     )
 
@@ -48,8 +44,6 @@ class AssignTransformer(ast.NodeTransformer):
         return node
 
     def visit_Assign(self, node):
-        if not isinstance(node.value, ast.Name):
-            return node
         new_node = gen_assign_checker_ast(node)
         ast.copy_location(new_node, node)
         ast.fix_missing_locations(new_node)


### PR DESCRIPTION
So we have this example:
```python
class T():
    def __assign__(self, v):
        print('called with %s' % v)


b = T()
c = b
```
It only prints "called with c", but "called with b" is missing. Because currently only simple variable names are transformed, more complex expressions are not touched. This proposed change solves this problem. Whatever it is on the right hand side of the assignment, will be checked for the existance of ```__assign__``` attribute and if it exists, it will be called. After applying the proposed change, it prints "called with b" and "called with c" for the below code:
```python
class T():
    def __assign__(self, v):
        print('called with %s' % v)
        return self


def func():
    return b

b = T()
c = func()
```