### PR TITLE
Support newer python versions

### DIFF
--- a/assign/magic.py
+++ b/assign/magic.py
@@ -1,5 +1,6 @@
 from assign.transformer import AssignTransformer
 from assign.patch import patch_module
+import sys
 
 __all__ = ['custom_import']
 
@@ -9,6 +10,8 @@ origin_import = __import__
 def custom_import(name, *args, **kwargs):
     module = origin_import(name, *args, **kwargs)
     if not hasattr(module, '__file__'):
+        return module
+    if module.__name__ == "warnings":
         return module
     try:
         patch_module(module, trans=AssignTransformer)

--- a/assign/magic.py
+++ b/assign/magic.py
@@ -1,6 +1,5 @@
 from assign.transformer import AssignTransformer
 from assign.patch import patch_module
-import sys
 
 __all__ = ['custom_import']
 


### PR DESCRIPTION
So this is our test module:
```python
class T():
    def __assign__(self, v):
        print('called with %s' % v)


b = T()
c = b
```
On my python version (3.13.0) importing it results in a infinite freeze. The reason for that is while patching the module, some internal ast functions attempts to import the warnings module, we try to patch warnings module and while doing that ast imports warnings again and this results in an infinite recursion. Proposed change solves this problem.